### PR TITLE
.cabal: allow opengl-2.6

### DIFF
--- a/Monadius.cabal
+++ b/Monadius.cabal
@@ -26,7 +26,7 @@ Executable monadius
                      , array     >= 0.3 && < 0.5
                      , directory >= 1.1 && < 1.2
                      , GLUT      >= 2.2 && < 2.4
-                     , OpenGL    >= 2.4 && < 2.6
+                     , OpenGL    >= 2.4 && < 2.7
 
   Hs-source-dirs:      Monadius
   Ghc-options:         -Wall


### PR DESCRIPTION
Signed-off-by: Sergei Trofimovich slyfox@gentoo.org
