### PR TITLE
port to GLUT-2.5 (DebugMessage collision)

### DIFF
--- a/src/Monadius.hs
+++ b/src/Monadius.hs
@@ -17,7 +17,7 @@ import Data.Array ((!), Array(), array)
 import Data.Complex
 import Data.List
 import Data.Maybe
-import Graphics.UI.GLUT hiding (position)
+import Graphics.UI.GLUT hiding (position, DebugMessage)
 
 import Game
 import Util


### PR DESCRIPTION
Detected by ghc as:
  src/Monadius.hs:595:20:
    Ambiguous occurrence ‘DebugMessage’
    It could refer to either ‘Monadius.DebugMessage’,
                             defined at src/Monadius.hs:137:3
                          or ‘Graphics.UI.GLUT.DebugMessage’,
                             imported from ‘Graphics.UI.GLUT’ at src/Monadius.hs:20:1-41
                             (and originally defined in ‘Graphics.Rendering.OpenGL.GL.DebugOutput’)

Signed-off-by: Sergei Trofimovich siarheit@google.com
